### PR TITLE
fix single \n bug

### DIFF
--- a/pagedown/Markdown.Converter.js
+++ b/pagedown/Markdown.Converter.js
@@ -1165,7 +1165,7 @@ else
             var end = grafs.length;
             for (var i = 0; i < end; i++) {
                 var str = grafs[i];
-
+                str = str.replace(/\n/g, " ");
                 // if this is an HTML marker, copy it
                 if (markerRe.test(str)) {
                     grafsOut.push(str);


### PR DESCRIPTION
In markdown, single '\n' is replace by space.