### PR TITLE
add support for an exclude: init option

### DIFF
--- a/Markdown.Extra.js
+++ b/Markdown.Extra.js
@@ -120,7 +120,7 @@
     });
     return text;
   }
-  
+
   function slugify(text) {
     return text.toLowerCase()
     .replace(/\s+/g, '-') // Replace spaces with -
@@ -144,7 +144,7 @@
     // Stores html blocks we generate in hooks so that
     // they're not destroyed if the user is using a sanitizing converter
     this.hashBlocks = [];
-    
+
     // Stores footnotes
     this.footnotes = {};
     this.usedFootnotes = [];
@@ -175,6 +175,9 @@
     options.extensions = options.extensions || ["all"];
     if (contains(options.extensions, "all")) {
       options.extensions = ["tables", "fenced_code_gfm", "def_list", "attr_list", "footnotes", "smartypants", "strikethrough", "newlines"];
+    }
+    if (options.exclude) {
+      options.extensions = options.extensions.filter(function(i) {return options.exclude.indexOf(i) < 0;});
     }
     preBlockGamutTransformations.push("wrapHeaders");
     if (contains(options.extensions, "attr_list")) {
@@ -209,7 +212,7 @@
     if (contains(options.extensions, "newlines")) {
       postSpanGamutTransformations.push("newlines");
     }
-    
+
     converter.hooks.chain("postNormalization", function(text) {
       return extra.doTransform(postNormalizationTransformations, text) + '\n';
     });
@@ -268,7 +271,7 @@
   Markdown.Extra.prototype.hashExtraInline = function(block) {
     return '~X' + (this.hashBlocks.push(block) - 1) + 'X';
   };
-  
+
   // Replace placeholder blocks in `text` with their corresponding
   // html blocks in the hashBlocks array.
   Markdown.Extra.prototype.unHashExtraBlocks = function(text) {
@@ -287,7 +290,7 @@
     recursiveUnHash();
     return text;
   };
-  
+
   // Wrap headers to make sure they won't be in def lists
   Markdown.Extra.prototype.wrapHeaders = function(text) {
     function wrap(text) {
@@ -312,11 +315,11 @@
     "(?=[\\-|=]+\\s*(?:\\n|0x03))", "gm"); // underline lookahead
   var fcbAttributes =  new RegExp("^(```[^`\\n]*)[ \\t]+" + attrBlock + "[ \\t]*\\n" +
     "(?=([\\s\\S]*?)\\n```[ \\t]*(\\n|0x03))", "gm");
-      
+
   // Extract headers attribute blocks, move them above the element they will be
   // applied to, and hash them for later.
   Markdown.Extra.prototype.hashHeaderAttributeBlocks = function(text) {
-    
+
     var self = this;
     function attributeCallback(wholeMatch, pre, attr) {
       return '<p>~XX' + (self.hashBlocks.push(attr) - 1) + 'XX</p>\n' + pre + "\n";
@@ -326,7 +329,7 @@
     text = text.replace(hdrAttributesB, attributeCallback);  // underline headers
     return text;
   };
-  
+
   // Extract FCB attribute blocks, move them above the element they will be
   // applied to, and hash them for later.
   Markdown.Extra.prototype.hashFcbAttributeBlocks = function(text) {
@@ -494,7 +497,7 @@
   /******************************************************************
    * Footnotes                                                      *
    *****************************************************************/
-  
+
   // Strip footnote, store in hashes.
   Markdown.Extra.prototype.stripFootnoteDefinitions = function(text) {
     var self = this;
@@ -511,7 +514,7 @@
 
     return text;
   };
-  
+
 
   // Find and convert footnotes references.
   Markdown.Extra.prototype.doFootnotes = function(text) {
@@ -564,8 +567,8 @@
     text += '</ol>\n</div>';
     return text;
   };
-  
-  
+
+
   /******************************************************************
   * Fenced Code Blocks  (gfm)                                       *
   ******************************************************************/
@@ -576,7 +579,7 @@
       code = code.replace(/&/g, "&amp;");
       code = code.replace(/</g, "&lt;");
       code = code.replace(/>/g, "&gt;");
-      // These were escaped by PageDown before postNormalization 
+      // These were escaped by PageDown before postNormalization
       code = code.replace(/~D/g, "$$");
       code = code.replace(/~T/g, "~");
       return code;
@@ -612,7 +615,7 @@
   /******************************************************************
   * SmartyPants                                                     *
   ******************************************************************/
-  
+
   Markdown.Extra.prototype.educatePants = function(text) {
     var self = this;
     var result = '';
@@ -642,7 +645,7 @@
     self.smartyPantsLastChar = result.substring(result.length - 1);
     return result;
   };
-    
+
   function revertPants(wholeMatch, m1) {
     var blockText = m1;
     blockText = blockText.replace(/&\#8220;/g, "\"");
@@ -654,7 +657,7 @@
     blockText = blockText.replace(/&\#8230;/g, "...");
     return blockText;
   }
-  
+
   Markdown.Extra.prototype.applyPants = function(text) {
     // Dashes
     text = text.replace(/---/g, "&#8212;").replace(/--/g, "&#8211;");
@@ -662,7 +665,7 @@
     text = text.replace(/\.\.\./g, "&#8230;").replace(/\.\s\.\s\./g, "&#8230;");
     // Backticks
     text = text.replace(/``/g, "&#8220;").replace (/''/g, "&#8221;");
-    
+
     if(/^'$/.test(text)) {
       // Special case: single-character ' token
       if(/\S/.test(this.smartyPantsLastChar)) {
@@ -690,24 +693,24 @@
 
     // Special case for decade abbreviations (the '80s):
     text = text.replace(/'(?=\d{2}s)/g, "&#8217;");
-    
+
     // Get most opening single quotes:
     text = text.replace(/(\s|&nbsp;|--|&[mn]dash;|&\#8211;|&\#8212;|&\#x201[34];)'(?=\w)/g, "$1&#8216;");
-    
+
     // Single closing quotes:
     text = text.replace(/([^\s\[\{\(\-])'/g, "$1&#8217;");
     text = text.replace(/'(?=\s|s\b)/g, "&#8217;");
 
     // Any remaining single quotes should be opening ones:
     text = text.replace(/'/g, "&#8216;");
-    
+
     // Get most opening double quotes:
     text = text.replace(/(\s|&nbsp;|--|&[mn]dash;|&\#8211;|&\#8212;|&\#x201[34];)"(?=\w)/g, "$1&#8220;");
-    
+
     // Double closing quotes:
     text = text.replace(/([^\s\[\{\(\-])"/g, "$1&#8221;");
     text = text.replace(/"(?=\s)/g, "&#8221;");
-    
+
     // Any remaining quotes should be opening ones.
     text = text.replace(/"/ig, "&#8220;");
     return text;
@@ -721,7 +724,7 @@
     text = text.replace(/(<([a-zA-Z1-6]+)\b([^\n>]*?)(\/)?>)/g, revertPants);
     return text;
   };
-  
+
   /******************************************************************
   * Definition Lists                                                *
   ******************************************************************/
@@ -869,6 +872,6 @@
       return previousTag ? wholeMatch : " <br>\n";
     });
   };
-  
+
 })();
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,10 @@ same naming scheme as the excellent Python Markdown library.
 
 *Italicized extensions are planned, and will be added in roughly the order shown*
 
+You can also enable all but a subset of extensions by using `exclude` to
+list one or more extensions to exclude:
+`{exclude: ["newlines"]}`
+
 See PHP Markdown Extra's [documentation][12] for a more complete overview
 of syntax. In situations where it differs from how things are done on GitHub --
 alignment of table headers, for instance -- I've chosen compatibility with gfm, which

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -105,6 +105,7 @@ for this editor.
 ```javascript
   Markdown.Extra.init(converter2, {
     extensions: "all",
+    exclude: ["newlines"],
     highlighter: "prettify"
   });
 ```
@@ -114,12 +115,17 @@ for this editor.
         </div>
         <div id="wmd-preview-second" class="wmd-panel wmd-preview"></div>
 
+        <div id="wmd-preview-third" class="wmd-panel">
+        This text will be replaced by Markdown converted to HTML. 
+        </div>
+
         <script type="text/javascript">
             (function () {
 
                 var converter1 = Markdown.getSanitizingConverter();
                 Markdown.Extra.init(converter1, {
                   extensions: "all",
+                  exclude: ["newlines"],
                   highlighter: "prettify"
                 });
 
@@ -137,7 +143,7 @@ for this editor.
                 });
                 
                 // "all" is the default
-                Markdown.Extra.init(converter2, {highlighter: "prettify"});
+                Markdown.Extra.init(converter2, {highlighter: "prettify", exclude: ["newlines"]});
 
                 var help = function () { alert("Do you need help?"); }
                 var options = {
@@ -148,7 +154,21 @@ for this editor.
                 editor2.hooks.chain("onPreviewRefresh", prettyPrint); // google code prettify
                 
                 editor2.run();
+
+                // show simpler example with the editor
+                var text = 'See more at **[pagedown-extra on GitHub](https://github.com/DavidBiesack/pagedown-extra)**'
+                var converter = new Markdown.Converter();
+                // tell the converter to use Markdown Extra
+                Markdown.Extra.init(converter);
+                // convert some markdown
+                var html = converter.makeHtml(text);
+                // and put it into the current HTML docuemmt; in this case,
+                // inside the element with id 'wmd-preview-third'
+                document.getElementById("wmd-preview-third").innerHTML=html
+
             })();
+
+
         </script>
     </body>
 </html>

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -155,7 +155,7 @@ for this editor.
                 
                 editor2.run();
 
-                // show simpler example with the editor
+                // show simpler example without the editor, just DOM manipulation.
                 var text = 'See more at **[pagedown-extra on GitHub](https://github.com/DavidBiesack/pagedown-extra)**'
                 var converter = new Markdown.Converter();
                 // tell the converter to use Markdown Extra

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagedown-extra",
-  "version": "0.1.0",
+  "version": "0.1.1",
   
   "main": "node-pagedown-extra.js",
   "devDependencies": {

--- a/spec/javascripts/specs/MarkdownExtraSpec.js
+++ b/spec/javascripts/specs/MarkdownExtraSpec.js
@@ -109,6 +109,7 @@ describe("Markdown.Extra", function() {
   var strikethroughHtml = '<p><del>Mistaken text.</del></p>';
   var newlines = 'Roses are red\nViolets are blue';
   var newlinesHtml = '<p>Roses are red <br>\nViolets are blue</p>';
+  var noNewlinesHtml = '<p>Roses are red\nViolets are blue</p>';
 
   // some basic markdown without extensions
   var markdown = "#TestHeader\n_This_ is *markdown*" +
@@ -522,6 +523,19 @@ describe("Markdown.Extra", function() {
       it("should convert new lines properly", function() {
         var html = strip(sconv.makeHtml(newlines));
         expect(html).toEqual(newlinesHtml);
+      });
+
+    });
+
+    describe("exclude newlines", function() {
+      beforeEach(function() {
+        sconv = Markdown.getSanitizingConverter();
+          Markdown.Extra.init(sconv, {extensions: "all", exclude: ["newlines"]});
+      });
+
+      it("should ignore new lines", function() {
+        var html = strip(sconv.makeHtml(newlines));
+        expect(html).toEqual(noNewlinesHtml);
       });
 
     });


### PR DESCRIPTION
Add exclude: to init() for enhancememt #66 and a specs test to verify it works.

I also added another example to demo.html to demonstrate using without the editor, so that the editor page links back to jmcmanus/pagedown-extra

bumped version number